### PR TITLE
basic nix flake with hls

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,31 @@
+{
+  description = "An intuitive, dynamically-typed DataFrame library";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+
+        hsPkgs = pkgs.haskellPackages.extend (self: super: {
+          dataframe = self.callCabal2nix "dataframe" ./. { };
+        });
+      in
+      {
+        packages = {
+          default = hsPkgs.dataframe;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            ghc
+            cabal-install
+            haskell-language-server
+          ];
+        };
+      });
+}


### PR DESCRIPTION
This is just a very basic nix flake that can be used with `nix develop` Currently it only sets up a basic ghc env with hls but later it would be improved to pin dependencies and provide easier environment setups. 