### PR TITLE
Use pprof format for profile output

### DIFF
--- a/run_profiling.sh
+++ b/run_profiling.sh
@@ -1,3 +1,30 @@
 #!/bin/bash
 
-cabal v2-run --enable-profiling dataframe -- +RTS -hy -l-agu
+PROF_TYPE=""
+
+if [ -z "$1" ]; then
+  # Default to eventlog profile if no argument given
+  PROF_TYPE="eventlog"
+else
+  case "$1" in
+    "eventlog")
+      PROF_TYPE="eventlog"
+      ;;
+    "pprof")
+      PROF_TYPE="pprof"
+      ;;
+    *)
+      echo "invalid profile type $1, should be one of 'eventlog' or 'pprof'"
+      exit 1
+      ;;
+  esac
+fi
+
+case "$PROF_TYPE" in
+  "eventlog")
+    cabal v2-run --enable-profiling dataframe -- +RTS -hy -l-agu
+    ;;
+  "pprof")
+    cabal v2-run --enable-profiling dataframe -- +RTS -pj -RTS
+    ;;
+esac


### PR DESCRIPTION
Example of pprof profiling instead of eventlog. Outputs .prof format that can be opened in e.g speedscope.app