### PR TITLE
Remove unnecessary IO Flush to improve column temp file write performance

### DIFF
--- a/src/Data/DataFrame/IO.hs
+++ b/src/Data/DataFrame/IO.hs
@@ -35,7 +35,7 @@ import Data.List (transpose, foldl')
 import Data.Maybe ( fromMaybe )
 import GHC.IO (unsafePerformIO)
 import GHC.IO.Handle
-    ( hClose, hFlush, hSeek, SeekMode(AbsoluteSeek), hIsEOF )
+    ( hClose, hSeek, SeekMode(AbsoluteSeek), hIsEOF )
 import GHC.IO.Handle.Types (Handle)
 import GHC.Stack (HasCallStack)
 import Text.Read (readMaybe)
@@ -103,7 +103,7 @@ mkColumns :: Char -> [(String, Handle)] -> Handle -> IO ()
 mkColumns c tmpFiles inputHandle = do
     row <- TIO.hGetLine inputHandle
     let splitRow = split c row
-    zipWithM_ (\s (f, h) -> TIO.hPutStrLn h s >> hFlush h) splitRow tmpFiles
+    zipWithM_ (\s (f, h) -> TIO.hPutStrLn h s) splitRow tmpFiles
     isEOF <- hIsEOF inputHandle
     if isEOF then return () else mkColumns c tmpFiles inputHandle
 


### PR DESCRIPTION
By default files open are in `BlockBuffering` mode with a OS dependent chunk size. This means writes are automatically flushed when the buffer is full or when the file is closed. We can remove the manual IO flushes because they only add syscall overhead.

Benchmark using the Kaggle credit card fraud data set: https://www.kaggle.com/datasets/mlg-ulb/creditcardfraud?resource=download

Before 52.7s to read CSV:

![image](https://github.com/user-attachments/assets/99be5e66-f572-46df-8333-f08357a1fdb3)

After: 40.3s to read CSV:

![image](https://github.com/user-attachments/assets/25e45e73-c823-4642-83c8-2a88ee170033)