### PR TITLE
fix: `declareColumns` now correctly sanitizes Haskell Identifiers passed to it

### DIFF
--- a/dataframe.cabal
+++ b/dataframe.cabal
@@ -258,6 +258,7 @@ test-suite tests
     type: exitcode-stdio-1.0
     main-is: Main.hs
     other-modules: Assertions,
+                   Functions,
                    Operations.Apply,
                    Operations.Derive,
                    Operations.Filter,

--- a/src/DataFrame/Functions.hs
+++ b/src/DataFrame/Functions.hs
@@ -112,12 +112,12 @@ isReservedId t = case t of
 
 isVarId :: T.Text -> Bool
 isVarId t = case T.uncons t of
--- We might want to check  c == '_' || Char.isLowerCase c
+-- We might want to check  c == '_' || Char.isLower c
 -- since the haskell report considers '_' a lowercase character
 -- However, to prevent an edge case where a user may have a
 -- "Name" and an "_Name_" in the same scope, wherein we'd end up
 -- with duplicate "_Name_"s, we eschew the check for '_' here.
-  Just (c, _) -> Char.isLowerCase c && Char.isAlpha c
+  Just (c, _) -> Char.isLower c && Char.isAlpha c
   Nothing -> False
 
 isHaskellIdentifier :: T.Text -> Bool

--- a/src/DataFrame/Functions.hs
+++ b/src/DataFrame/Functions.hs
@@ -146,7 +146,7 @@ declareColumns df = let
         types = map (columnTypeString . (`unsafeGetColumn` df)) names
         specs = zipWith (\name type_ -> (sanitize name, type_)) names types
         sanitize t = if isValidIdentifier t
-                     then "_" <> T.filter Char.isAlpha t <> "_"
+                     then "_" <> T.filter Char.isAlphaNum t <> "_"
                      else t
     in fmap concat $ forM specs $ \(nm, tyStr) -> do
         ty  <- typeFromString (words tyStr)

--- a/src/DataFrame/Functions.hs
+++ b/src/DataFrame/Functions.hs
@@ -120,7 +120,7 @@ isVarId t = case T.uncons t of
   Nothing -> False
 
 isValidIdentifier :: T.Text -> Bool
-isValidIdentifier t =  not (isVarId t || isReservedId t)
+isValidIdentifier t =  not (isVarId t) || isReservedId t
 
 typeFromString :: [String] -> Q Type
 typeFromString []  = fail "No type specified"

--- a/tests/Functions.hs
+++ b/tests/Functions.hs
@@ -1,0 +1,42 @@
+{-# LANGUAGE OverloadedStrings #-}
+module Functions where
+
+import Control.Exception
+import Test.HUnit
+import DataFrame.Functions (sanitize)
+import qualified Data.Text as T
+
+-- Test cases for the sanitize function
+sanitizeIdentifiers :: Test
+sanitizeIdentifiers = TestList
+  [ TestCase $ assertEqual "Reserved word 'Data' should become '_data_'"
+      "_data_" (sanitize "Data")
+  
+  , TestCase $ assertEqual "Spaces should become underscores"
+      "my_data" (sanitize "My Data")
+  
+  , TestCase $ assertEqual "Punctuation and parentheses should be handled"
+      "distance_km_h" (sanitize "Distance (km/h)")
+  
+  , TestCase $ assertEqual "Leading digit should be wrapped"
+      "_0_age_" (sanitize "0 Age")
+  
+  , TestCase $ assertEqual "Valid camelCase should be unchanged"
+      "camelCaseStr" (sanitize "camelCaseStr")
+  
+  , TestCase $ assertEqual "Valid camelCase with invalid characters mixed in"
+      "camelcase_str" (sanitize "camelCase$Str")
+
+  , TestCase $ assertEqual "Valid snake_case should remain unchanged"
+      "snake_case_str" (sanitize "snake_case_str")
+  
+  , TestCase $ assertEqual "Leading digit with snake_case should be wrapped"
+      "_12_snake_case_" (sanitize "12_snake_case")
+  
+  , TestCase $ assertEqual "All symbols should become underscores"
+      "_____" (sanitize "***")
+  ]
+
+tests :: [Test]
+tests = pure $ TestLabel "sanitizeIdentifiers" sanitizeIdentifiers
+

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -16,6 +16,7 @@ import Test.HUnit
 
 import Assertions
 
+import qualified Functions
 import qualified Operations.Apply
 import qualified Operations.Derive
 import qualified Operations.Filter
@@ -76,6 +77,7 @@ tests = TestList $ dimensionsTest
                 ++ Operations.InsertColumn.tests
                 ++ Operations.Sort.tests
                 ++ Operations.Take.tests
+                ++ Functions.tests
                 ++ parseTests
 
 main :: IO ()


### PR DESCRIPTION
- We use section 2.4 of the [Haskell 2010 report](https://www.haskell.org/definition/haskell2010.pdf) to define the conditions under which a string is a valid Haskell Identifier.
- If it is, we sanitize it by filtering everything except alphanumeric characters and wrapping it in `_`s.