### PR TITLE
feat: Scaffold up Elixir's Explorer benchmark.

### DIFF
--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -29,6 +29,12 @@ pandas = do
     output <- readProcess "./benchmark/dataframe_benchmark/bin/python3" ["./benchmark/pandas/pandas_benchmark.py"] ""
     putStrLn output
 
+explorer :: IO ()
+explorer = do
+    _ <- readProcess "./benchmark/dataframe_benchmark/bin/mix" ["deps.get"] ""
+    output <- readProcess "./benchmark/dataframe_benchmark/bin/mix" ["run", "./benchmark/explorer/explorer_benchmark.exs"] ""
+    putStrLn output
+
 groupByHaskell :: IO ()
 groupByHaskell = do
     df <- D.readCsv "./data/housing.csv"
@@ -50,6 +56,11 @@ groupByPandas = do
     output <- readProcess "./benchmark/dataframe_benchmark/bin/python3" ["./benchmark/pandas/group_by.py"] ""
     putStrLn output
 
+groupByExplorer :: IO ()
+groupByExplorer = do
+    output <- readProcess "./benchmark/dataframe_benchmark/bin/mix" ["run", "./benchmark/explorer/group_by.exs"] ""
+    putStrLn output
+
 main = do
     output <- readProcess "cabal" ["build", "-O2"] ""
     putStrLn output
@@ -59,8 +70,10 @@ main = do
             [ bench "simpleStatsHaskell" $ nfIO haskell
             , bench "simpleStatsPandas" $ nfIO pandas
             , bench "simpleStatsPolars" $ nfIO polars
+            , bench "simpleStatsExplorer" $ nfIO explorer
             , bench "groupByHaskell" $ nfIO groupByHaskell
             , bench "groupByPolars" $ nfIO groupByPolars
             , bench "groupByPandas" $ nfIO groupByPandas
+            , bench "groupByExplorer" $ nfIO groupByExplorer
             ]
         ]

--- a/benchmark/explorer/explorer_benchmark.exs
+++ b/benchmark/explorer/explorer_benchmark.exs
@@ -1,0 +1,53 @@
+alias Explorer.DataFrame
+alias Explorer.Series
+
+require DataFrame
+
+Nx.global_default_backend(EXLA.Backend)
+
+format_time = fn start_time, end_time ->
+  diff = end_time - start_time
+  seconds = div(diff, 1_000_000)
+  microseconds = rem(diff, 1_000_000)
+  "#{seconds}.#{microseconds}"
+end
+
+size = 100_000_000
+
+first = System.monotonic_time(:microsecond)
+
+key = Nx.Random.key(System.system_time(:nanosecond) |> rem(:math.pow(2, 32) |> round))
+
+df =
+  Explorer.DataFrame.new(%{
+    "normal" => Nx.Random.normal(key, 0, 1, shape: {size, 1}) |> elem(0),
+    "log_normal" => Nx.Random.normal(key, 0, 1, shape: {size, 1}) |> elem(0) |> Nx.exp(),
+    "exponential" =>
+      Nx.subtract(1.0, Nx.Random.uniform(key, 0, 1, shape: {size, 1}) |> elem(0))
+      |> Nx.log()
+      |> Nx.negate()
+  })
+
+second = System.monotonic_time(:microsecond)
+
+IO.puts("Data generation/load time: #{format_time.(first, second)}")
+
+mean = Series.mean(df["normal"])
+var = Series.variance(df["log_normal"])
+corr = Series.correlation(df["exponential"], df["log_normal"])
+
+IO.puts("#{mean}, #{var}, #{corr}")
+
+third = System.monotonic_time(:microsecond)
+
+df2 = DataFrame.filter(df, log_normal > 8.0)
+
+IO.puts("Number of rows after select: #{DataFrame.n_rows(df2)}")
+
+fourth = System.monotonic_time(:microsecond)
+
+IO.inspect(DataFrame.head(df, 10))
+
+IO.puts("Calculation time: #{format_time.(second, third)}")
+IO.puts("Selection time: #{format_time.(third, fourth)}")
+IO.puts("Overall time: #{format_time.(first, fourth)}")

--- a/benchmark/explorer/group_by.exs
+++ b/benchmark/explorer/group_by.exs
@@ -1,0 +1,15 @@
+alias Explorer.DataFrame
+
+require DataFrame
+
+df = DataFrame.from_csv!("./data/housing.csv")
+
+agg_df =
+  df
+  |> DataFrame.group_by("ocean_proximity")
+  |> DataFrame.summarise(
+    min_median_house_value: min(median_house_value),
+    max_median_house_value: max(median_house_value)
+  )
+
+IO.inspect(agg_df)

--- a/benchmark/explorer/mix.exs
+++ b/benchmark/explorer/mix.exs
@@ -1,0 +1,19 @@
+defmodule Benchmark.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :benchmark,
+      version: "0.1.0",
+      deps: deps()
+    ]
+  end
+
+  defp deps do
+    [
+      {:exla, "~> 0.10.0"},
+      {:explorer, "~> 0.11.1"},
+      {:nx, "~> 0.10.0"}
+    ]
+  end
+end


### PR DESCRIPTION
Hello @mchav,

I gave a try at adding a benchmark for Explorer, Elixir's dataframe library.
This should still be a draft, but maybe it can help addressing #38.

Compared to `pandas` and `polars` benchmarks:
- `group_by` seems consistent with its equivalents,
- the random distributions from `explorer_benchmark` seem in line in terms of mean and variance, but the correlations between them are completely different, and I don't get why.

Also, I do not get how the benchmark is launched, so I assume the changes in `Main.hs` will not work.

Hope it helps.

<img width="903" height="534" alt="explorer" src="https://github.com/user-attachments/assets/d7048bfa-d6f4-4339-966b-be1130414762" />
