### PR TITLE
Use more informative FilePath where applicable

### DIFF
--- a/src/DataFrame/IO/CSV.hs
+++ b/src/DataFrame/IO/CSV.hs
@@ -153,7 +153,7 @@ ghci> D.readCsv "./data/taxi.csv" df
 
 @
 -}
-readCsv :: String -> IO DataFrame
+readCsv :: FilePath -> IO DataFrame
 readCsv = readSeparated ',' defaultOptions
 
 {- | Read TSV (tab separated) file from path and load it into a dataframe.
@@ -164,7 +164,7 @@ ghci> D.readTsv "./data/taxi.tsv" df
 
 @
 -}
-readTsv :: String -> IO DataFrame
+readTsv :: FilePath -> IO DataFrame
 readTsv = readSeparated '\t' defaultOptions
 
 {- | Read text file with specified delimiter into a dataframe.
@@ -175,7 +175,7 @@ ghci> D.readSeparated ';' D.defaultOptions "./data/taxi.txt" df
 
 @
 -}
-readSeparated :: Char -> ReadOptions -> String -> IO DataFrame
+readSeparated :: Char -> ReadOptions -> FilePath -> IO DataFrame
 readSeparated !sep !opts !path = withFile path ReadMode $ \handle -> do
     hSetBuffering handle (BlockBuffering (Just (chunkSize opts)))
 
@@ -355,14 +355,14 @@ freezeGrowingColumn (GrowingText gv nullsRef) = do
                     else VM.write mvec i (Just (vec V.! i))
             OptionalColumn <$> V.freeze mvec
 
-writeCsv :: String -> DataFrame -> IO ()
+writeCsv :: FilePath -> DataFrame -> IO ()
 writeCsv = writeSeparated ','
 
 writeSeparated ::
     -- | Separator
     Char ->
     -- | Path to write to
-    String ->
+    FilePath ->
     DataFrame ->
     IO ()
 writeSeparated c filepath df = withFile filepath WriteMode $ \handle -> do

--- a/src/DataFrame/IO/Parquet.hs
+++ b/src/DataFrame/IO/Parquet.hs
@@ -36,7 +36,7 @@ ghci> D.readParquet "./data/mtcars.parquet" df
 
 @
 -}
-readParquet :: String -> IO DataFrame
+readParquet :: FilePath -> IO DataFrame
 readParquet path = do
     fileMetadata <- readMetadataFromPath path
     let columnPaths = getColumnPaths (drop 1 $ schema fileMetadata)

--- a/src/DataFrame/Lazy/IO/CSV.hs
+++ b/src/DataFrame/Lazy/IO/CSV.hs
@@ -65,18 +65,18 @@ defaultOptions = ReadOptions{hasHeader = True, inferTypes = True, safeRead = Tru
 Note this file stores intermediate temporary files
 while converting the CSV from a row to a columnar format.
 -}
-readCsv :: String -> IO DataFrame
+readCsv :: FilePath -> IO DataFrame
 readCsv path = fst <$> readSeparated ',' defaultOptions path
 
 {- | Reads a tab separated file from the given path.
 Note this file stores intermediate temporary files
 while converting the CSV from a row to a columnar format.
 -}
-readTsv :: String -> IO DataFrame
+readTsv :: FilePath -> IO DataFrame
 readTsv path = fst <$> readSeparated '\t' defaultOptions path
 
 -- | Reads a character separated file into a dataframe using mutable vectors.
-readSeparated :: Char -> ReadOptions -> String -> IO (DataFrame, (Integer, T.Text, Int))
+readSeparated :: Char -> ReadOptions -> FilePath -> IO (DataFrame, (Integer, T.Text, Int))
 readSeparated c opts path = do
     totalRows <- case totalRows opts of
         Nothing -> countRows c path >>= \total -> if hasHeader opts then return (total - 1) else return total
@@ -289,14 +289,14 @@ countRows c path = withFile path ReadMode $! go 0 ""
                         go (n + 1) unconsumed h
 {-# INLINE countRows #-}
 
-writeCsv :: String -> DataFrame -> IO ()
+writeCsv :: FilePath -> DataFrame -> IO ()
 writeCsv = writeSeparated ','
 
 writeSeparated ::
     -- | Separator
     Char ->
     -- | Path to write to
-    String ->
+    FilePath ->
     DataFrame ->
     IO ()
 writeSeparated c filepath df = withFile filepath WriteMode $ \handle -> do


### PR DESCRIPTION
Hello,
thanks for working on this package! I'm rooting for you and am curious how far you'll be able to take it :crossed_fingers: 
Yesterday I went through the haddocks and found couple of minor issues (improper use of haddock markup, broken links etc). Are you accepting PRs in this area?

Here's a small improvement to make few type signatures more informative (and consistent with what [haddocks](https://github.com/mchav/dataframe/blob/d61d2fb4b0bfa8f4d9c1bc76b93d0fa36d65b356/src/DataFrame.hs#L82-L84) say): even though FilePath is just type synonym for String, I find it more informative. And since it's in base, I think there's no reason not to use it :slightly_smiling_face: 