### PR TITLE
Fix -Wunused-imports

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -6,11 +6,6 @@
 {-# LANGUAGE TypeApplications #-}
 
 import qualified DataFrame as D -- import for general functionality.
-import qualified DataFrame.Functions as F -- import for column expressions.
-
-import DataFrame ((|>)) -- import chaining operator with unqualified.
-
-import Control.Monad (replicateM)
 import Data.Time
 import qualified Data.Vector.Unboxed as VU
 import System.Random.Stateful

--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -2,17 +2,12 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TypeApplications #-}
 
-import qualified Data.Vector.Unboxed as VU
-import qualified Data.Vector.Unboxed.Mutable as VUM
 import qualified DataFrame as D
 import qualified DataFrame.Functions as F
 
-import Control.Monad (replicateM)
 import Criterion.Main
-import Data.Time
 import DataFrame ((|>))
 import System.Process
-import System.Random.Stateful
 
 haskell :: IO ()
 haskell = do

--- a/dataframe.cabal
+++ b/dataframe.cabal
@@ -23,7 +23,7 @@ source-repository head
 
 common warnings
     -- TODO add more warnings, eventually -Wall
-    ghc-options: -Wunused-packages
+    ghc-options: -Wunused-packages -Wunused-imports
 
 library
     import: warnings
@@ -75,7 +75,6 @@ library
                       bytestring-lexing >= 0.5 && < 0.6,
                       containers >= 0.6.7 && < 0.8,
                       directory >= 1.3.0.0 && < 2,
-                      filepath >= 1.0.0.0 && < 2,
                       granite ^>= 0.2,
                       hashable >= 1.2 && < 2,
                       process ^>= 1.6,
@@ -111,9 +110,6 @@ benchmark dataframe-benchmark
     build-depends: base > 4 && < 5,
                    criterion >= 1 && < 2,
                    process >= 1.6 && < 2,
-                   time >= 1.12 && < 2,
-                   random >= 1 && < 2,
-                   vector ^>= 0.13,
                    dataframe ^>= 0.3
     default-language: Haskell2010
 

--- a/src/DataFrame.hs
+++ b/src/DataFrame.hs
@@ -265,9 +265,6 @@ import DataFrame.Operations.Subset as Subset (
  )
 import DataFrame.Operations.Transformations as Transformations
 
-import Data.Function
-import Data.List
-import qualified Data.Text as T
-import qualified Data.Text.IO as T
+import Data.Function ((&))
 
 (|>) = (&)

--- a/src/DataFrame/Display/Terminal/Plot.hs
+++ b/src/DataFrame/Display/Terminal/Plot.hs
@@ -11,7 +11,6 @@ module DataFrame.Display.Terminal.Plot where
 import Control.Monad
 import qualified Data.List as L
 import qualified Data.Map as M
-import Data.Maybe (catMaybes, fromMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Data.Type.Equality (TestEquality (testEquality), type (:~:) (Refl))
@@ -22,10 +21,9 @@ import qualified Data.Vector.Unboxed as VU
 import GHC.Stack (HasCallStack)
 import Type.Reflection (typeRep)
 
-import DataFrame.Internal.Column (Column (..), Columnable, isNumeric)
+import DataFrame.Internal.Column (Column (..), isNumeric)
 import qualified DataFrame.Internal.Column as D
 import DataFrame.Internal.DataFrame (DataFrame (..), getColumn)
-import DataFrame.Internal.Types
 import DataFrame.Operations.Core
 import qualified DataFrame.Operations.Subset as D
 import Granite

--- a/src/DataFrame/Display/Web/Plot.hs
+++ b/src/DataFrame/Display/Web/Plot.hs
@@ -12,7 +12,7 @@ import Control.Monad
 import Data.Char
 import qualified Data.List as L
 import qualified Data.Map as M
-import Data.Maybe (catMaybes, fromMaybe)
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import Data.Type.Equality (TestEquality (testEquality), type (:~:) (Refl))
@@ -21,16 +21,13 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Unboxed as VU
 import GHC.Stack (HasCallStack)
-import System.IO (writeFile)
 import System.Random (newStdGen, randomRs)
 import Type.Reflection (typeRep)
 
-import Control.Monad (void)
 import DataFrame.Display.Web.ChartJs
-import DataFrame.Internal.Column (Column (..), Columnable, isNumeric)
+import DataFrame.Internal.Column (Column (..), isNumeric)
 import qualified DataFrame.Internal.Column as D
 import DataFrame.Internal.DataFrame (DataFrame (..), getColumn)
-import DataFrame.Internal.Types
 import DataFrame.Operations.Core
 import qualified DataFrame.Operations.Subset as D
 import System.Directory

--- a/src/DataFrame/Errors.hs
+++ b/src/DataFrame/Errors.hs
@@ -11,7 +11,6 @@ import qualified Data.Vector.Unboxed as VU
 
 import Control.Exception
 import Data.Array
-import Data.Either
 import Data.Typeable (Typeable)
 import DataFrame.Display.Terminal.Colours
 import Type.Reflection (TypeRep)

--- a/src/DataFrame/Functions.hs
+++ b/src/DataFrame/Functions.hs
@@ -21,18 +21,15 @@ import DataFrame.Internal.Statistics
 
 import Control.Monad
 import qualified Data.Char as Char
-import qualified Data.Foldable as F
 import Data.Function
 import qualified Data.List as L
 import qualified Data.Map as M
 import qualified Data.Text as T
-import qualified Data.Vector as VB
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Unboxed as VU
 import Debug.Trace (traceShow)
 import Language.Haskell.TH
 import qualified Language.Haskell.TH.Syntax as TH
-import Type.Reflection (typeRep)
 
 name :: (Show a) => Expr a -> T.Text
 name (Col n) = n

--- a/src/DataFrame/IO/CSV.hs
+++ b/src/DataFrame/IO/CSV.hs
@@ -23,9 +23,8 @@ import qualified Data.Vector.Mutable as VM
 import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector.Unboxed.Mutable as VUM
 
-import Control.Applicative (many, (*>), (<$>), (<*), (<*>), (<|>))
-import Control.Monad (forM_, unless, void, when, zipWithM_)
-import Control.Monad.ST (runST)
+import Control.Applicative (many, (<|>))
+import Control.Monad (forM_, unless, zipWithM_)
 import Data.Attoparsec.ByteString.Char8 hiding (endOfLine)
 import Data.Bits (shiftL)
 import Data.Char
@@ -34,15 +33,10 @@ import Data.Function (on)
 import Data.Functor
 import Data.IORef
 import Data.Maybe
-import Data.Type.Equality (
-    TestEquality (testEquality),
-    type (:~:) (Refl),
- )
-import DataFrame.Internal.Column (Column (..), MutableColumn (..), columnLength, freezeColumn', fromVector, writeColumn)
+import Data.Type.Equality (TestEquality (testEquality))
+import DataFrame.Internal.Column (Column (..), columnLength)
 import DataFrame.Internal.DataFrame (DataFrame (..))
 import DataFrame.Internal.Parsing
-import DataFrame.Operations.Typing
-import GHC.IO.Handle (Handle)
 import System.IO
 import Type.Reflection
 import Prelude hiding (concat, takeWhile)

--- a/src/DataFrame/IO/Parquet.hs
+++ b/src/DataFrame/IO/Parquet.hs
@@ -8,7 +8,6 @@ import Control.Monad
 import Data.Bits
 import qualified Data.ByteString as BSO
 import Data.Char
-import Data.Foldable
 import Data.IORef
 import Data.Int
 import qualified Data.List as L
@@ -18,10 +17,8 @@ import qualified Data.Text as T
 import Data.Word
 import qualified DataFrame.Internal.Column as DI
 import DataFrame.Internal.DataFrame (DataFrame)
-import qualified DataFrame.Internal.DataFrame as DI
 import qualified DataFrame.Operations.Core as DI
 
-import DataFrame.IO.Parquet.Binary
 import DataFrame.IO.Parquet.Dictionary
 import DataFrame.IO.Parquet.Levels
 import DataFrame.IO.Parquet.Page

--- a/src/DataFrame/IO/Parquet/Dictionary.hs
+++ b/src/DataFrame/IO/Parquet/Dictionary.hs
@@ -17,8 +17,6 @@ import DataFrame.IO.Parquet.Time
 import DataFrame.IO.Parquet.Types
 import qualified DataFrame.Internal.Column as DI
 import GHC.Float
-import GHC.IO (unsafePerformIO)
-import Text.Printf
 
 dictCardinality :: DictVals -> Int
 dictCardinality (DBool ds) = length ds

--- a/src/DataFrame/IO/Parquet/Encoding.hs
+++ b/src/DataFrame/IO/Parquet/Encoding.hs
@@ -1,8 +1,6 @@
 module DataFrame.IO.Parquet.Encoding where
 
 import Data.Bits
-import Data.Foldable
-import Data.List (foldl', mapAccumL)
 import Data.Word
 import DataFrame.IO.Parquet.Binary
 

--- a/src/DataFrame/IO/Parquet/Page.hs
+++ b/src/DataFrame/IO/Parquet/Page.hs
@@ -4,25 +4,16 @@
 module DataFrame.IO.Parquet.Page where
 
 import Codec.Compression.Zstd.Streaming
-import Control.Monad
 import Data.Bits
 import qualified Data.ByteString as BSO
-import Data.Char
-import Data.Foldable
 import Data.Int
-import Data.List
 import Data.Maybe
-import qualified Data.Text as T
 import Data.Word
 import DataFrame.IO.Parquet.Binary
-import DataFrame.IO.Parquet.Dictionary
-import DataFrame.IO.Parquet.Levels
 import DataFrame.IO.Parquet.Thrift
 import DataFrame.IO.Parquet.Types
-import qualified DataFrame.Internal.Column as DI
 import GHC.Float
-import qualified Snappy as Snappy
-import Text.Printf
+import qualified Snappy
 
 isDataPage :: Page -> Bool
 isDataPage page = case pageTypeHeader (pageHeader page) of

--- a/src/DataFrame/IO/Parquet/Time.hs
+++ b/src/DataFrame/IO/Parquet/Time.hs
@@ -2,7 +2,6 @@
 
 module DataFrame.IO.Parquet.Time where
 
-import Data.Int
 import Data.Time
 import Data.Word
 

--- a/src/DataFrame/Internal/Column.hs
+++ b/src/DataFrame/Internal/Column.hs
@@ -17,8 +17,6 @@
 
 module DataFrame.Internal.Column where
 
-import qualified Data.ByteString.Char8 as C
-import qualified Data.List as L
 import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Vector as VB
@@ -30,19 +28,12 @@ import qualified Data.Vector.Unboxed.Mutable as VUM
 
 import Control.Exception (throw)
 import Control.Monad.ST (runST)
-import Data.Int
-import Data.Kind (Constraint, Type)
 import Data.Maybe
-import Data.Proxy
-import Data.Text.Encoding (decodeUtf8Lenient)
-import Data.Type.Equality (TestEquality (..), type (:~:) (Refl))
-import Data.Typeable (Typeable, cast)
-import Data.Word
+import Data.Type.Equality (TestEquality (..))
 import DataFrame.Errors
 import DataFrame.Internal.Parsing
 import DataFrame.Internal.Types
 import Type.Reflection
-import Unsafe.Coerce (unsafeCoerce)
 
 {- | Our representation of a column is a GADT that can store data based on the underlying data.
 

--- a/src/DataFrame/Internal/DataFrame.hs
+++ b/src/DataFrame/Internal/DataFrame.hs
@@ -16,7 +16,6 @@ import qualified Data.Vector.Unboxed as VU
 
 import Data.Function (on)
 import Data.List (sortBy, transpose, (\\))
-import Data.Maybe (isJust)
 import Data.Type.Equality (TestEquality (testEquality), type (:~:) (Refl))
 import DataFrame.Display.Terminal.PrettyPrint
 import DataFrame.Internal.Column

--- a/src/DataFrame/Internal/Expression.hs
+++ b/src/DataFrame/Internal/Expression.hs
@@ -14,7 +14,6 @@
 module DataFrame.Internal.Expression where
 
 import Control.Exception (throw)
-import Data.Data (Typeable)
 import qualified Data.Map as M
 import Data.Maybe (fromMaybe)
 import qualified Data.Text as T

--- a/src/DataFrame/Internal/Row.hs
+++ b/src/DataFrame/Internal/Row.hs
@@ -22,15 +22,14 @@ import Control.Monad.ST (runST)
 import Data.Function (on)
 import Data.Maybe (fromMaybe)
 import Data.Type.Equality (TestEquality (..))
-import Data.Typeable (Typeable, type (:~:) (..))
-import Data.Word (Word16, Word32, Word64, Word8)
+import Data.Typeable (type (:~:) (..))
 import DataFrame.Errors (DataFrameException (..))
 import DataFrame.Internal.Column
 import DataFrame.Internal.DataFrame
 import DataFrame.Internal.Types
 import Text.ParserCombinators.ReadPrec (ReadPrec)
 import Text.Read (Lexeme (Ident), lexP, parens, readListPrec, readListPrecDefault, readPrec)
-import Type.Reflection (TypeRep, typeOf, typeRep)
+import Type.Reflection (typeOf, typeRep)
 
 data Any where
     Value :: (Columnable' a) => a -> Any

--- a/src/DataFrame/Internal/Schema.hs
+++ b/src/DataFrame/Internal/Schema.hs
@@ -13,7 +13,7 @@ import qualified Data.Proxy as P
 import qualified Data.Text as T
 
 import Data.Maybe
-import Data.Type.Equality (TestEquality (..), type (:~:) (Refl))
+import Data.Type.Equality (TestEquality (..))
 import DataFrame.Internal.Column
 import Type.Reflection (typeRep)
 

--- a/src/DataFrame/Internal/Statistics.hs
+++ b/src/DataFrame/Internal/Statistics.hs
@@ -3,15 +3,11 @@
 
 module DataFrame.Internal.Statistics where
 
-import qualified Data.Text as T
-import qualified Data.Vector as V
 import qualified Data.Vector.Algorithms.Intro as VA
-import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector.Unboxed.Mutable as VUM
 
 import Control.Exception (throw)
-import Control.Monad
 import Control.Monad.ST (runST)
 import DataFrame.Errors (DataFrameException (..))
 

--- a/src/DataFrame/Internal/Types.hs
+++ b/src/DataFrame/Internal/Types.hs
@@ -15,13 +15,9 @@ module DataFrame.Internal.Types where
 
 import Data.Int (Int16, Int32, Int64, Int8)
 import Data.Kind (Constraint, Type)
-import Data.Maybe (fromMaybe)
-import Data.Type.Equality (TestEquality (..))
-import Data.Typeable (Typeable, type (:~:) (..))
-import qualified Data.Vector as VB
+import Data.Typeable (Typeable)
 import qualified Data.Vector.Unboxed as VU
 import Data.Word (Word16, Word32, Word64, Word8)
-import Type.Reflection (TypeRep, typeOf, typeRep)
 
 type Columnable' a = (Typeable a, Show a, Ord a, Eq a, Read a)
 

--- a/src/DataFrame/Lazy/IO/CSV.hs
+++ b/src/DataFrame/Lazy/IO/CSV.hs
@@ -8,37 +8,28 @@
 
 module DataFrame.Lazy.IO.CSV where
 
-import qualified Data.ByteString.Char8 as C
 import qualified Data.List as L
 import qualified Data.Map as M
 import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Text.IO as TIO
-import qualified Data.Text.Lazy as TL
-import qualified Data.Text.Lazy.IO as TLIO
 import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as VM
 import qualified Data.Vector.Unboxed as VU
 import qualified Data.Vector.Unboxed.Mutable as VUM
 
-import Control.Applicative (many, (*>), (<$>), (<*), (<*>), (<|>))
-import Control.Monad (forM_, replicateM_, unless, void, when, zipWithM_)
+import Control.Applicative (many, (<|>))
+import Control.Monad (forM_, unless, when, zipWithM_)
 import Data.Attoparsec.Text
 import Data.Char
 import Data.Foldable (fold)
 import Data.Function (on)
 import Data.IORef
 import Data.Maybe
-import Data.Text.Encoding (decodeUtf8Lenient)
-import Data.Type.Equality (
-    TestEquality (testEquality),
-    type (:~:) (Refl),
- )
+import Data.Type.Equality (TestEquality (testEquality))
 import DataFrame.Internal.Column (Column (..), MutableColumn (..), columnLength, freezeColumn', writeColumn)
 import DataFrame.Internal.DataFrame (DataFrame (..))
 import DataFrame.Internal.Parsing
-import DataFrame.Operations.Typing
-import GHC.IO.Handle (Handle)
 import System.IO
 import Type.Reflection
 import Prelude hiding (concat, takeWhile)

--- a/src/DataFrame/Lazy/Internal/DataFrame.hs
+++ b/src/DataFrame/Lazy/Internal/DataFrame.hs
@@ -8,22 +8,16 @@
 
 module DataFrame.Lazy.Internal.DataFrame where
 
-import Control.Monad (foldM, forM)
-import Data.IORef
-import Data.Kind
+import Control.Monad (foldM)
 import qualified Data.List as L
-import qualified Data.Map as M
 import qualified Data.Text as T
-import qualified Data.Vector as V
 import qualified DataFrame.Internal.Column as C
 import qualified DataFrame.Internal.DataFrame as D
 import qualified DataFrame.Internal.Expression as E
 import qualified DataFrame.Lazy.IO.CSV as D
-import qualified DataFrame.Operations.Core as D
-import DataFrame.Operations.Merge
+import DataFrame.Operations.Merge ()
 import qualified DataFrame.Operations.Subset as D
 import qualified DataFrame.Operations.Transformations as D
-import System.FilePath
 
 data LazyOperation where
     Derive :: (C.Columnable a) => T.Text -> E.Expr a -> LazyOperation

--- a/src/DataFrame/Operations/Aggregation.hs
+++ b/src/DataFrame/Operations/Aggregation.hs
@@ -8,44 +8,30 @@
 
 module DataFrame.Operations.Aggregation where
 
-import qualified Data.Set as S
-import qualified DataFrame.Functions as F
-
 import qualified Data.List as L
 import qualified Data.Map as M
-import qualified Data.Map.Strict as MS
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Data.Vector.Algorithms.Merge as VA
 import qualified Data.Vector.Generic as VG
-import qualified Data.Vector.Mutable as VM
 import qualified Data.Vector.Unboxed as VU
 
 import Control.Exception (throw)
-import Control.Monad (foldM_)
 import Control.Monad.ST (runST)
-import Data.Function ((&))
 import Data.Hashable
-import Data.List ((\\))
-import Data.Maybe
 import Data.Type.Equality (TestEquality (..), type (:~:) (Refl))
 import DataFrame.Errors
 import DataFrame.Internal.Column (
     Column (..),
     Columnable,
     atIndicesStable,
-    columnVersionString,
-    fromVector,
     getIndices,
     getIndicesUnboxed,
     unwrapTypedColumn,
  )
-import DataFrame.Internal.DataFrame (DataFrame (..), GroupedDataFrame (..), empty, getColumn, unsafeGetColumn)
+import DataFrame.Internal.DataFrame (DataFrame (..), GroupedDataFrame (..))
 import DataFrame.Internal.Expression
-import DataFrame.Internal.Parsing
-import DataFrame.Internal.Types
 import DataFrame.Operations.Core
-import DataFrame.Operations.Merge
 import DataFrame.Operations.Subset
 import Type.Reflection (typeOf, typeRep)
 

--- a/src/DataFrame/Operations/Core.hs
+++ b/src/DataFrame/Operations/Core.hs
@@ -21,10 +21,10 @@ import Control.Exception (throw)
 import Data.Either
 import Data.Function (on, (&))
 import Data.Maybe
-import Data.Type.Equality (TestEquality (..), type (:~:) (Refl))
+import Data.Type.Equality (TestEquality (..))
 import DataFrame.Errors
 import DataFrame.Internal.Column (Column (..), Columnable, columnLength, columnTypeString, expandColumn, fromList, fromVector)
-import DataFrame.Internal.DataFrame (DataFrame (..), empty, getColumn, null)
+import DataFrame.Internal.DataFrame (DataFrame (..), empty, getColumn)
 import DataFrame.Internal.Parsing (isNullish)
 import Type.Reflection
 import Prelude hiding (null)

--- a/src/DataFrame/Operations/Merge.hs
+++ b/src/DataFrame/Operations/Merge.hs
@@ -4,7 +4,6 @@ module DataFrame.Operations.Merge where
 
 import qualified Data.List as L
 import qualified Data.Text as T
-import qualified Data.Vector as V
 import qualified DataFrame.Internal.Column as D
 import qualified DataFrame.Internal.DataFrame as D
 import qualified DataFrame.Operations.Core as D

--- a/src/DataFrame/Operations/Sorting.hs
+++ b/src/DataFrame/Operations/Sorting.hs
@@ -9,7 +9,7 @@ import qualified Data.Vector as V
 import Control.Exception (throw)
 import DataFrame.Errors (DataFrameException (..))
 import DataFrame.Internal.Column
-import DataFrame.Internal.DataFrame (DataFrame (..), getColumn)
+import DataFrame.Internal.DataFrame (DataFrame (..))
 import DataFrame.Internal.Row
 import DataFrame.Operations.Core
 

--- a/src/DataFrame/Operations/Statistics.hs
+++ b/src/DataFrame/Operations/Statistics.hs
@@ -9,35 +9,28 @@
 
 module DataFrame.Operations.Statistics where
 
-import Data.Bifunctor (second)
 import qualified Data.List as L
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Vector as V
-import qualified Data.Vector.Algorithms.Intro as VA
 import qualified Data.Vector.Generic as VG
 import qualified Data.Vector.Unboxed as VU
-import qualified Data.Vector.Unboxed.Mutable as VUM
 
 import Prelude as P
 
 import Control.Exception (throw)
 import Control.Monad
-import Control.Monad.ST (runST)
-import qualified Data.Bifunctor as Data
-import Data.Foldable (asum)
 import Data.Function ((&))
 import Data.Maybe (fromMaybe, isJust)
 import Data.Type.Equality (TestEquality (testEquality), type (:~:) (Refl))
 import DataFrame.Errors (DataFrameException (..))
 import DataFrame.Internal.Column
-import DataFrame.Internal.DataFrame (DataFrame (..), empty, getColumn, unsafeGetColumn)
+import DataFrame.Internal.DataFrame (DataFrame (..), empty, getColumn)
 import DataFrame.Internal.Row (showValue, toAny)
 import DataFrame.Internal.Statistics
 import DataFrame.Internal.Types
 import DataFrame.Operations.Core
 import DataFrame.Operations.Subset (filterJust)
-import GHC.Float (int2Double)
 import Text.Printf (printf)
 import Type.Reflection (typeRep)
 

--- a/src/DataFrame/Operations/Subset.hs
+++ b/src/DataFrame/Operations/Subset.hs
@@ -11,7 +11,6 @@ module DataFrame.Operations.Subset where
 
 import qualified Data.List as L
 import qualified Data.Map as M
-import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Data.Vector.Generic as VG
@@ -23,12 +22,11 @@ import Control.Exception (throw)
 import Control.Monad.ST
 import Data.Function ((&))
 import Data.Maybe (fromJust, fromMaybe, isJust, isNothing)
-import Data.Type.Equality (TestEquality (..), type (:~:) (Refl))
+import Data.Type.Equality (TestEquality (..))
 import DataFrame.Errors (DataFrameException (..), TypeErrorContext (..))
 import DataFrame.Internal.Column
 import DataFrame.Internal.DataFrame (DataFrame (..), empty, getColumn)
 import DataFrame.Internal.Expression
-import DataFrame.Internal.Row (Any, mkRowFromArgs, toAny)
 import DataFrame.Operations.Core
 import DataFrame.Operations.Transformations (apply)
 import Type.Reflection

--- a/src/DataFrame/Operations/Transformations.hs
+++ b/src/DataFrame/Operations/Transformations.hs
@@ -10,18 +10,15 @@ import qualified Data.List as L
 import qualified Data.Map as M
 import qualified Data.Text as T
 import qualified Data.Vector as V
-import qualified Data.Vector.Generic as VG
-import qualified Data.Vector.Unboxed as VU
 
 import Control.Exception (throw)
 import Data.Maybe
 import DataFrame.Errors (DataFrameException (..), TypeErrorContext (..))
-import DataFrame.Internal.Column (Column (..), Columnable, TypedColumn (TColumn), columnTypeString, ifoldrColumn, imapColumn, mapColumn, unwrapTypedColumn)
+import DataFrame.Internal.Column (Column (..), Columnable, columnTypeString, ifoldrColumn, imapColumn, mapColumn, unwrapTypedColumn)
 import DataFrame.Internal.DataFrame (DataFrame (..), getColumn)
 import DataFrame.Internal.Expression
-import DataFrame.Internal.Row (Any, mkRowFromArgs, toAny)
 import DataFrame.Operations.Core
-import Type.Reflection (TypeRep, typeOf, typeRep)
+import Type.Reflection (TypeRep, typeRep)
 
 -- | O(k) Apply a function to a given column in a dataframe.
 apply ::

--- a/src/DataFrame/Operations/Typing.hs
+++ b/src/DataFrame/Operations/Typing.hs
@@ -6,7 +6,6 @@
 
 module DataFrame.Operations.Typing where
 
-import qualified Data.Set as S
 import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU

--- a/tests/Functions.hs
+++ b/tests/Functions.hs
@@ -2,8 +2,6 @@
 
 module Functions where
 
-import Control.Exception
-import qualified Data.Text as T
 import DataFrame.Functions (sanitize)
 import Test.HUnit
 

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -3,23 +3,15 @@
 
 module Main where
 
-import qualified Data.List as L
 import qualified Data.Text as T
 import qualified Data.Vector as V
-import qualified Data.Vector.Unboxed as VU
 import qualified DataFrame as D
-import qualified DataFrame.Internal.Column as D
 import qualified DataFrame.Internal.Column as DI
-import qualified DataFrame.Internal.DataFrame as D
-import qualified DataFrame.Internal.DataFrame as DI
 import qualified DataFrame.Operations.Typing as D
 import qualified System.Exit as Exit
 
-import Control.Exception
 import Data.Time
 import Test.HUnit
-
-import Assertions
 
 import qualified Functions
 import qualified Operations.Apply

--- a/tests/Operations/Apply.hs
+++ b/tests/Operations/Apply.hs
@@ -9,7 +9,6 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import qualified DataFrame as D
 import qualified DataFrame as DE
-import qualified DataFrame.Internal.Column as D
 import qualified DataFrame.Internal.Column as DI
 import qualified DataFrame.Internal.DataFrame as D
 import qualified DataFrame.Internal.DataFrame as DI

--- a/tests/Operations/Derive.hs
+++ b/tests/Operations/Derive.hs
@@ -6,17 +6,12 @@ module Operations.Derive where
 
 import qualified Data.Text as T
 import qualified Data.Vector as V
-import qualified Data.Vector.Unboxed as VU
 import qualified DataFrame as D
 import qualified DataFrame.Functions as F
-import qualified DataFrame.Internal.Column as D
 import qualified DataFrame.Internal.Column as DI
-import qualified DataFrame.Internal.DataFrame as D
 import qualified DataFrame.Internal.DataFrame as DI
 
-import Assertions
 import Test.HUnit
-import Type.Reflection (typeRep)
 
 values :: [(T.Text, DI.Column)]
 values =

--- a/tests/Operations/Filter.hs
+++ b/tests/Operations/Filter.hs
@@ -4,13 +4,8 @@
 module Operations.Filter where
 
 import qualified Data.Text as T
-import qualified Data.Vector as V
-import qualified Data.Vector.Unboxed as VU
 import qualified DataFrame as D
-import qualified DataFrame.Internal.Column as D
 import qualified DataFrame.Internal.Column as DI
-import qualified DataFrame.Internal.DataFrame as D
-import qualified DataFrame.Internal.DataFrame as DI
 
 import Assertions
 import Test.HUnit

--- a/tests/Operations/GroupBy.hs
+++ b/tests/Operations/GroupBy.hs
@@ -3,13 +3,10 @@
 module Operations.GroupBy where
 
 import qualified Data.Text as T
-import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import qualified DataFrame as D
-import qualified DataFrame.Internal.Column as D
 import qualified DataFrame.Internal.Column as DI
 import qualified DataFrame.Internal.DataFrame as D
-import qualified DataFrame.Internal.DataFrame as DI
 
 import Assertions
 import Test.HUnit

--- a/tests/Operations/InsertColumn.hs
+++ b/tests/Operations/InsertColumn.hs
@@ -7,12 +7,9 @@ import qualified Data.Text as T
 import qualified Data.Vector as V
 import qualified Data.Vector.Unboxed as VU
 import qualified DataFrame as D
-import qualified DataFrame.Internal.Column as D
 import qualified DataFrame.Internal.Column as DI
-import qualified DataFrame.Internal.DataFrame as D
 import qualified DataFrame.Internal.DataFrame as DI
 
-import Assertions
 import Test.HUnit
 
 testData :: D.DataFrame

--- a/tests/Operations/Sort.hs
+++ b/tests/Operations/Sort.hs
@@ -3,16 +3,10 @@
 module Operations.Sort where
 
 import Assertions
-import Control.Monad
 import Data.Char
 import qualified Data.Text as T
-import qualified Data.Vector as V
-import qualified Data.Vector.Unboxed as VU
 import qualified DataFrame as D
-import qualified DataFrame.Internal.Column as D
 import qualified DataFrame.Internal.Column as DI
-import qualified DataFrame.Internal.DataFrame as D
-import qualified DataFrame.Internal.DataFrame as DI
 import System.Random
 import System.Random.Shuffle (shuffle')
 import Test.HUnit

--- a/tests/Operations/Statistics.hs
+++ b/tests/Operations/Statistics.hs
@@ -6,8 +6,6 @@ module Operations.Statistics where
 
 import qualified Data.Vector.Unboxed as VU
 import qualified DataFrame as D
-import qualified DataFrame.Internal.Column as D
-import qualified DataFrame.Internal.DataFrame as D
 import qualified DataFrame.Internal.Statistics as D
 
 import Assertions

--- a/tests/Operations/Take.hs
+++ b/tests/Operations/Take.hs
@@ -3,10 +3,8 @@
 module Operations.Take where
 
 import qualified DataFrame as D
-import qualified DataFrame.Internal.Column as D
 import qualified DataFrame.Internal.Column as DI
 import qualified DataFrame.Internal.DataFrame as D
-import qualified DataFrame.Internal.DataFrame as DI
 
 import Test.HUnit
 

--- a/tests/Parquet.hs
+++ b/tests/Parquet.hs
@@ -4,11 +4,9 @@ module Parquet where
 
 import qualified DataFrame as D
 
-import Assertions
 import Data.Int
 import Data.Text (Text)
 import Data.Time
-import Data.Time.Calendar
 import GHC.IO (unsafePerformIO)
 import Test.HUnit
 


### PR DESCRIPTION
Part 1 in the series of "fixing useful GHC warnings" PRs.

Fixing unused imports might seem annoying, but haskell-language-server makes it easy via "remove all unused imports" code action. A nice thing about keeping imports clean is that it can sometimes lead to identifying and removing unused dependencies as this PR shows.