### PR TITLE
feat: Add script to set up and run benchmark.

### DIFF
--- a/benchmark/Main.hs
+++ b/benchmark/Main.hs
@@ -27,8 +27,7 @@ pandas = do
 
 explorer :: IO ()
 explorer = do
-    _ <- readProcess "./benchmark/dataframe_benchmark/bin/mix" ["deps.get"] ""
-    output <- readProcess "./benchmark/dataframe_benchmark/bin/mix" ["run", "./benchmark/explorer/explorer_benchmark.exs"] ""
+    output <- readProcess "mix" ["run", "./benchmark/explorer/explorer_benchmark.exs"] ""
     putStrLn output
 
 groupByHaskell :: IO ()
@@ -54,7 +53,7 @@ groupByPandas = do
 
 groupByExplorer :: IO ()
 groupByExplorer = do
-    output <- readProcess "./benchmark/dataframe_benchmark/bin/mix" ["run", "./benchmark/explorer/group_by.exs"] ""
+    output <- readProcess "mix" ["run", "./benchmark/explorer/group_by.exs"] ""
     putStrLn output
 
 parseFile :: String -> IO ()

--- a/benchmark/explorer/mix.exs
+++ b/benchmark/explorer/mix.exs
@@ -5,15 +5,18 @@ defmodule Benchmark.MixProject do
     [
       app: :benchmark,
       version: "0.1.0",
-      deps: deps()
+      deps: deps(),
+      lockfile: Path.expand("mix.lock", __DIR__),
+      deps_path: Path.expand("deps", __DIR__),
+      build_path: Path.expand("_build", __DIR__)
     ]
   end
 
   defp deps do
     [
-      {:exla, "~> 0.10.0"},
+      #{:exla, "~> 0.10.0"},
       {:explorer, "~> 0.11.1"},
-      {:nx, "~> 0.10.0"}
+      #{:nx, "~> 0.10.0"}
     ]
   end
 end

--- a/scripts/benchmark.sh
+++ b/scripts/benchmark.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+export MIX_EXS="$PWD/benchmark/explorer/mix.exs"
+
+VENV_DIR="./benchmark/dataframe_benchmark"
+EXPLORER_DIR="./benchmark/explorer"
+
+if ! command -v python3 &> /dev/null; then
+    echo -e "\nPython3 is not installed.\n"
+    exit 1
+fi
+
+if ! command -v elixir &> /dev/null; then
+    echo -e "\nElixir is not installed.\n"
+    exit 1
+fi
+
+echo -e "\nSetting up Python environment...\n"
+
+python3 -m venv "$VENV_DIR"
+
+source "$VENV_DIR/bin/activate"
+
+pip install --upgrade pip
+pip install numpy pandas polars
+
+echo -e "\nPython environment ready.\n"
+
+echo -e "Setting up Elixir environment...\n"
+
+mix deps.get
+mix deps.loadpaths
+
+echo -e "\nElixir environment ready.\n"
+
+echo -e "Running benchmark...\n"
+
+cabal bench -O2
+
+echo -e "\nCleaning up...\n"
+
+rm -rf "$VENV_DIR"
+find "$EXPLORER_DIR" -mindepth 1 | grep -v '\.exs$' | xargs -I{} rm -rf "{}"
+
+echo "Done!"


### PR DESCRIPTION
Adding a BASH script to setup Python and Elixir environments, run the benchmark, and do some cleanup afterwards.
I commented out a couple dependencies in `mix.exs` as they take time to install and are not used currently.