### PR TITLE
Dataframe will run faster in ghci if we change the dataframe.sh script to use `-fobject-code`

### DIFF
--- a/scripts/dataframe.sh
+++ b/scripts/dataframe.sh
@@ -6,5 +6,5 @@ fi
 
 cabal update
 
-cabal repl --ghc-options="-O2 -fobject-code" --build-depends dataframe --repl-option=-ghci-script=dataframe.ghci
+cabal repl --repl-options="-O2 -fobject-code" --build-depends dataframe --repl-option=-ghci-script=dataframe.ghci
 


### PR DESCRIPTION
Running `cabal repl -O2` still has the library running far slower than it probably should. Parsing the 9 MB csv file "effects-of-covid-19-on-trade-at-15-december-2021-provisional.csv" takes over 9 seconds on my machine

 I found that it runs much faster when I do `cabal repl --ghc-options="-O2 -fobject-code"`. The `-fobject-code` makes ghci use the compiled object code instead of the interpreted byte code which gives an order of magnitude difference from what I see. Reference: https://downloads.haskell.org/ghc/7.8.3/docs/html/users_guide/ghci-obj.html

The tradeoff, of course, is that the first time the user spins up the dataframe repl it'll be much slower