### PR TITLE
[refinement] modify sortBy API to allow sorting by multiple columns

### DIFF
--- a/docs/coming_from_other_implementations.md
+++ b/docs/coming_from_other_implementations.md
@@ -269,7 +269,7 @@ python> df.sort_values(by='E')
 Since we don't support row indexes, we only provide column-based sorting. You specify the sort direction and column names:
 
 ```haskell
-ghci> D.sortBy D.Ascending ["E"] df
+ghci> D.sortBy [D.Asc "E"] df
 -------------------------------------------------------
    A    |     B      |   C   |  D  |     E     |   F   
 --------|------------|-------|-----|-----------|-------
@@ -1039,7 +1039,7 @@ starwars %>%
 
 ```haskell
 starwars 
-  |> D.sortBy D.Descending ["mass"]
+  |> D.sortBy [D.Desc "mass"]
 ```
 
 **Output (truncated):**
@@ -1057,7 +1057,7 @@ starwars
  Darth Vader           | Just 202  | Just 136  | ...
 ```
 
-For multi-column sorting, provide multiple column names: `D.sortBy D.Descending ["mass", "height"]`
+For multi-column sorting, provide multiple column names: `D.sortBy [D.Desc "mass", D.Asc "height"]`
 
 ### Grouping and Summarizing
 

--- a/docs/cookbook.md
+++ b/docs/cookbook.md
@@ -262,11 +262,18 @@ dataframe> df |> D.filterWhere (F.lift even id) |> D.select [F.name city] |> D.d
 
 ## Sorting and Combining Results
 
-Sometimes you need to sort data and then combine results from multiple queries. The `sortBy` function orders rows by specified columns, and you can use the `<>` operator to concatenate dataframes vertically (similar to SQL's UNION).
+Sometimes you need to sort data and then combine results from multiple queries. The `sortBy` function orders rows by specified columns. Much like SQL, you can specify multiple columns to
+order by. The results are ordered by the first column, with ties broken by the next column 
+respectively. 
+
+You can also can use the `<>` operator to concatenate dataframes vertically (similar to SQL's UNION).
 
 ```haskell
-df |> D.sortBy D.Ascending ["column"]   -- Sort ascending
-df |> D.sortBy D.Descending ["column"]  -- Sort descending
+-- Sort by ascending age
+df |> D.sortBy [D.Asc "age"]
+-- 1. Sort by descending age
+-- 2. Within those who have the same age, sort by alphabetical order of name.
+df |> D.sortBy [D.Asc "age", D.Desc "name"]  
 ```
 
 You can also derive new columns using `derive` to compute values based on existing columns:
@@ -292,8 +299,8 @@ UNION
 ```
 
 ```haskell
-dataframe> letterSort s = df |> D.derive "length" (F.lift T.length city) |> D.select [F.name city, "length"] |> D.sortBy s ["length"] |> D.take 1
-dataframe> (letterSort D.Descending) <> (letterSort D.Ascending)
+dataframe> letterSort s = df |> D.derive "length" (F.lift T.length city) |> D.select [F.name city, "length"] |> D.sortBy [s "length"] |> D.take 1
+dataframe> (letterSort D.Desc) <> (letterSort D.Asc)
 -------------------------------
          city          | length
 -----------------------|-------

--- a/docs/dataframes_in_haskell.md
+++ b/docs/dataframes_in_haskell.md
@@ -362,7 +362,7 @@ The API favors **consistency, small primitives, and composition**. Names mirror 
   * `rename :: Text -> Text -> DataFrame -> DataFrame`  
 * Rows (DSL-based)  
   * `filter :: Expr Bool -> DataFrame -> DataFrame`  
-  * `sortBy :: Order -> [Text] -> DataFrame -> DataFrame`  
+  * `sortBy :: [SortOrder] -> DataFrame -> DataFrame`  
   * `groupBy :: [UExpr] -> DataFrame -> DataFrame`  
 * Whole-frame  
   * `transpose :: DataFrame -> DataFrame`  

--- a/docs/intro_to_probability_and_data.md
+++ b/docs/intro_to_probability_and_data.md
@@ -404,7 +404,7 @@ variable which of the following statements is true?
 
 
 8. In what year did we see the most total number of births in the U.S.? *Hint:* Sort 
-your dataset in descending order based on the `total` column. You can do this with the new function: `D.sortBy D.Descending <column names to sort by>` (for 
+your dataset in descending order based on the `total` column. You can do this with the new function: `D.sortBy [D.Desc <column name to sort by>]` (for 
 descending order).
 <ol>
 <li> 1940 </li>

--- a/docs/persistent_integration.md
+++ b/docs/persistent_integration.md
@@ -107,7 +107,7 @@ analyzeUsers = runSqlite "test.db" $ do
         let youngUsers = DF.filter @Int "age" (< 30) df
         
         -- Sort
-        let sorted = DF.sortBy DF.Ascending ["age"] df
+        let sorted = DF.sortBy [DF.Asc "age"] df
         
         -- Derive columns
         let withAgeGroup = DF.derive "age_group"

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -235,7 +235,7 @@ let dfImput = D.impute (F.col @Double "sepal.length") 10 df
 ## 9) Sorting, Shuffling, Distinct, Sampling
 
 ```haskell
-D.sortBy D.Ascending ["variety"] df
+D.sortBy [D.Asc "variety"] df
 D.sample (mkStdGen 42) 0.1 df           -- 10% uniform random sample sample
 D.shuffle (mStdGen 42) df
 ```
@@ -246,7 +246,7 @@ D.shuffle (mStdGen 42) df
 
 ```haskell
 let (train, test) = D.randomSplit (mkStdGen 42) 0.8 (df |> D.insert "index" [1..(fst (D.dimensions df))])
-let original = train <> test |> D.sortBy D.Ascending ["index"]
+let original = train <> test |> D.sortBy [D.Asc "index"]
 ```
 
 ---

--- a/examples/Chipotle.hs
+++ b/examples/Chipotle.hs
@@ -75,7 +75,7 @@ main = do
                 , F.maximum (F.col @Int "quantity") `F.as` "max"
                 , F.mean (F.col @Int "quantity") `F.as` "mean"
                 ]
-            |> D.sortBy D.Descending ["sum"]
+            |> D.sortBy [D.Desc "sum"]
 
     print $
         df

--- a/examples/OneBillionRowChallenge.hs
+++ b/examples/OneBillionRowChallenge.hs
@@ -30,7 +30,7 @@ main = do
                 , F.mean measurement `F.as` "mean"
                 , F.maximum measurement `F.as` "maximum"
                 ]
-            |> D.sortBy D.Ascending ["city"]
+            |> D.sortBy [D.Asc "city"]
     endCalculation <- getCurrentTime
     let calculationTime = diffUTCTime endCalculation startCalculation
     putStrLn $ "Calculation Time: " ++ show calculationTime

--- a/tests/Operations/Join.hs
+++ b/tests/Operations/Join.hs
@@ -33,7 +33,7 @@ testInnerJoin =
                 , ("B", D.fromList ["B0" :: Text, "B1", "B2"])
                 ]
             )
-            (D.sortBy D.Ascending ["key"] (innerJoin ["key"] df1 df2))
+            (D.sortBy [D.Asc "key"] (innerJoin ["key"] df1 df2))
         )
 
 testLeftJoin :: Test
@@ -47,7 +47,7 @@ testLeftJoin =
                 , ("B", D.fromList [Just "B0", Just "B1" :: Maybe Text, Just "B2"])
                 ]
             )
-            (D.sortBy D.Ascending ["key"] (leftJoin ["key"] df2 df1))
+            (D.sortBy [D.Asc "key"] (leftJoin ["key"] df2 df1))
         )
 
 testRightJoin :: Test
@@ -61,7 +61,7 @@ testRightJoin =
                 , ("B", D.fromList ["B0" :: Text, "B1", "B2"])
                 ]
             )
-            (D.sortBy D.Ascending ["key"] (rightJoin ["key"] df2 df1))
+            (D.sortBy [D.Asc "key"] (rightJoin ["key"] df2 df1))
         )
 
 staffDf :: D.DataFrame
@@ -108,7 +108,7 @@ testFullOuterJoin =
                     )
                 ]
             )
-            (D.sortBy D.Ascending ["Name"] (fullOuterJoin ["Name"] studentDf staffDf))
+            (D.sortBy [D.Asc "Name"] (fullOuterJoin ["Name"] studentDf staffDf))
         )
 
 tests :: [Test]


### PR DESCRIPTION
Previously, you could only `sortBy` the entire `Row`, which meant handing over to the `Ord` instance for `Vector Any`. Here, I slightly modified `SortOrder` to also take in the column name, so as to allow for SQL-like `ORDER BY` semantics, where:

1. The results are ordered by the first column
2. Ties within the first column are broken by the second column
3. Ties within the first two columns are broken by the third column
4. And so on and so forth... 

This is accomplished by using the [Monoid instance for orderings](https://brandon.si/code/the-monoid-instance-for-ordering/). All the orderings are `<>`ed, in order, until a tiebreaker is found.

I have added a couple test cases to verify that this works.

I have also modified all instances of `sortBy` that I encountered in the tutorials.