### PR TITLE
fix `writeCsv` for `OptionalColumn` 

### DIFF
--- a/src/DataFrame/IO/CSV.hs
+++ b/src/DataFrame/IO/CSV.hs
@@ -428,7 +428,9 @@ getRowAsText df i = V.ifoldr go [] (columns df)
                     ++ "the other columns at index "
                     ++ show i
     go k (OptionalColumn (c :: V.Vector (Maybe a))) acc = case c V.!? i of
-        Just e -> maybe T.empty T.show e : acc
+        Just e -> case testEquality (typeRep @a) (typeRep @T.Text) of
+            Just Refl -> fromMaybe T.empty e : acc
+            Nothing -> maybe T.empty (T.pack . show) e : acc
         Nothing ->
             error $
                 "Column "

--- a/src/DataFrame/Lazy/IO/CSV.hs
+++ b/src/DataFrame/Lazy/IO/CSV.hs
@@ -383,7 +383,9 @@ getRowAsText df i = V.ifoldr go [] (columns df)
                     ++ "the other columns at index "
                     ++ show i
     go k (OptionalColumn (c :: V.Vector (Maybe a))) acc = case c V.!? i of
-        Just e -> maybe T.empty T.show e : acc
+        Just e -> case testEquality (typeRep @a) (typeRep @T.Text) of
+            Just Refl -> fromMaybe T.empty e : acc
+            Nothing -> maybe T.empty (T.pack . show) e : acc
         Nothing ->
             error $
                 "Column "


### PR DESCRIPTION
### Description

`writeCsv` was outputting optional (non-Text) values as text including Just/Nothing in the file. You can see this behaviour doing a read/write/read cycle (see below). On Windows btw.

### Example

#### Input

```haskell
dataframe> df <- D.readCsv "input.csv"
dataframe> df
--------------------------------------
id  | fld_a  |    fld_b    |   fld_c
----|--------|-------------|----------
Int | Double | Maybe Text  | Maybe Int
----|--------|-------------|----------
0   | 0.0    | Nothing     | Nothing
1   | 0.5    | Just "base" | Just 10
```

#### Behaviour before

```haskell
dataframe> D.writeCsv "before.csv" df >> D.readCsv "before.csv" >>= print
-------------------------------------------
id  | fld_a  |    fld_b    |     fld_c
----|--------|-------------|---------------
Int | Double | Maybe Text  |   Maybe Text
----|--------|-------------|---------------
0   | 0.0    | Nothing     | Nothing
1   | 0.5    | Just "base" | Just "Just 10"
```

#### Behaviour after

```haskell
dataframe> D.writeCsv "after.csv" df >> D.readCsv "after.csv" >>= print
--------------------------------------
id  | fld_a  |    fld_b    |   fld_c
----|--------|-------------|----------
Int | Double | Maybe Text  | Maybe Int
----|--------|-------------|----------
0   | 0.0    | Nothing     | Nothing
1   | 0.5    | Just "base" | Just 10
```