### PR TITLE
Un-break nix build + nix develop

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -22,12 +22,14 @@
           default = hsPkgs.dataframe;
         };
 
-        devShells.default = pkgs.mkShell {
-          buildInputs = with pkgs; [
+        devShells.default = hsPkgs.shellFor {
+          packages = ps: [ (ps.callCabal2nix "dataframe" ./. { }) ];
+          nativeBuildInputs = with pkgs; [
             ghc
             cabal-install
             haskell-language-server
           ];
+          withHoogle = true;
         };
       });
 }


### PR DESCRIPTION
On `main`, `nix build` fails with missing `random >=1.3 && <2`. That makes sense, since the version of `random` in `haskellPackages` in the flake inputs was 1.2.x. This PR overrides `random` in `hsPkgs` to pin to `1.3.1` instead. A consequence of that was that `time-compat` tests broke, because they [depend on random between 1.2 and 1.3](https://github.com/haskellari/time-compat/blob/eec6b9c5997300a9343a59ecd45689924da6f975/time-compat.cabal#L136), so it also overrides `time-compat` to skip tests.

This PR also updates the dev shell to provide a little more power. On `main`, if you `nix develop`, you get vanilla `cabal` without any knowledge of the project's dependencies, e.g.

```
$ cabal repl
Warning: The package list for 'hackage.haskell.org' does not exist. Run 'cabal
update' to download it.
Resolving dependencies...
Error: [Cabal-7107]
Could not resolve dependencies:
[__0] trying: dataframe-0.4.0.10 (user goal)
[__1] unknown package: zstd (dependency of dataframe)
[__1] fail (backjumping, conflict set: dataframe, zstd)
After searching the rest of the dependency tree exhaustively, these were the goals I've had most trouble fulfilling: dataframe, zstd
```

After changes in this PR, the dev shell is aware of the `dataframe` package, and `cabal repl` drops you into a shell with all of the project's modules, so if you have `foo.csv` like

```csv
a,b
1,2
3,4
```

you can

```
$ cabal repl
[...]
ghci> import DataFrame.IO.CSV
ghci> readCsv "foo.csv"
---------
 a  |  b
----|----
Int | Int
----|----
1   | 2
3   | 4
```