### PR TITLE
fix broken `cabal build` in Windows

### DIFF
--- a/dataframe.cabal
+++ b/dataframe.cabal
@@ -157,8 +157,9 @@ executable dataframe
                       directory >= 1.3.0.0 && < 2,
                       filepath >= 1.4 && < 2,
                       process >= 1.6 && < 2,
-                      time >= 1.12 && < 2,
-                      unix >= 2 && < 3
+                      time >= 1.12 && < 2
+    if !os(windows)
+        build-depends: unix >= 2 && < 3
     hs-source-dirs:   app
     default-language: Haskell2010
     ghc-options: -rtsopts -threaded -with-rtsopts=-N


### PR DESCRIPTION
All fine in the source but think a check needed here as well.