### PR TITLE
feat: Add writeTsv function

### DIFF
--- a/src/DataFrame/IO/CSV.hs
+++ b/src/DataFrame/IO/CSV.hs
@@ -388,6 +388,9 @@ constructOptionalBoxed vec valid = do
 writeCsv :: FilePath -> DataFrame -> IO ()
 writeCsv = writeSeparated ','
 
+writeTsv :: FilePath -> DataFrame -> IO ()
+writeTsv = writeSeparated '\t'
+
 writeSeparated ::
     -- | Separator
     Char ->


### PR DESCRIPTION
I just copied the implementation of writeCsv here, so I don't really understand why there are lazy and non-lazy versions. @mchav could you help me understand this?
Also, I didn't write any tests because there were none for writeCsv, but I did check out the output in the REPL. Would it be worth adding tests for both of these write functions, or maybe just the writeSeparated function that does most of the work? Maybe just a string comparison of manually audited output for some small dataframe?

#119 