### PR TITLE
relax constraints on random

### DIFF
--- a/dataframe.cabal
+++ b/dataframe.cabal
@@ -105,7 +105,7 @@ library
                       hashable >= 1.2 && < 2,
                       process ^>= 1.6,
                       snappy-hs ^>= 0.1,
-                      random >= 1.2 && < 1.3,
+                      random >= 1.2 && < 2,
                       regex-tdfa >= 1.3.0 && < 2,
                       scientific >=0.3.1 && <0.4,
                       template-haskell >= 2.0 && < 3,


### PR DESCRIPTION
Follow-up to #169.

Nix won't have a problem with a relaxed random version, still using v1.2 (see comments), and this avoids a regression in Stackage (https://github.com/commercialhaskell/stackage/commit/441f6618ce5554253417c35550aead7d0e5c2976)

@juhp