### PR TITLE
Fix Functions module compilation in ghc 9.10

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -19,19 +19,25 @@
 
         hsPkgs = pkgs.haskellPackages.extend (self: super: rec {
           granite = self.callCabal2nix "granite" granitePkg { };
+          dataframe-fastcsv = self.callCabal2nix "dataframe-fastcsv" ./dataframe-fastcsv {
+            inherit parallel;
+          };
           dataframe = self.callCabal2nix "dataframe" ./. {
             inherit granite;
           };
+          parallel = super.parallel_3_3_0_0;
         });
       in
       {
         packages = {
           default = hsPkgs.dataframe;
+          dataframe = hsPkgs.dataframe;
+          dataframe-fastcsv = hsPkgs.dataframe-fastcsv;
         };
 
         devShells.default = hsPkgs.shellFor {
-          packages = ps: [ (ps.callCabal2nix "dataframe" ./. { }) ];
-          nativeBuildInputs = with pkgs; [
+          packages = ps: [ ps.dataframe ps.dataframe-fastcsv ];
+          nativeBuildInputs = with hsPkgs; [
             ghc
             cabal-install
             haskell-language-server

--- a/src/DataFrame/Functions.hs
+++ b/src/DataFrame/Functions.hs
@@ -2,6 +2,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE IncoherentInstances #-}
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
@@ -504,7 +505,8 @@ whenBothPresent f = lift2Decorated (\l r -> f <$> l <*> r) "whenBothPresent" Not
 
 recode ::
     forall a b.
-    (Columnable a, Columnable b) => [(a, b)] -> Expr a -> Expr (Maybe b)
+    (Columnable a, Columnable b, Show (a, b)) =>
+    [(a, b)] -> Expr a -> Expr (Maybe b)
 recode mapping =
     Unary
         ( MkUnaryOp
@@ -523,7 +525,7 @@ recodeWithCondition fallback ((cond, value) : rest) expr = ifThenElse (cond expr
 
 recodeWithDefault ::
     forall a b.
-    (Columnable a, Columnable b) => b -> [(a, b)] -> Expr a -> Expr b
+    (Columnable a, Columnable b, Show (a, b)) => b -> [(a, b)] -> Expr a -> Expr b
 recodeWithDefault d mapping =
     Unary
         ( MkUnaryOp


### PR DESCRIPTION
This PR:

* fixes the flake definition so that `dataframe` and `dataframe-fastcsv` both build
* replicates #192 in the flake
* fixes the compilation error from #192 by adding `IncoherentInstances` and an explicit `Show (a, b)` constraint