### PR TITLE
feat: implement row-major transpose (#191)

### DIFF
--- a/src/DataFrame/Functions.hs
+++ b/src/DataFrame/Functions.hs
@@ -809,3 +809,7 @@ declareColumnsWithPrefix' prefix df =
             sig <- sigD n [t|Expr $(pure ty)|]
             val <- valD (varP n) (normalB [|col $(TH.lift raw)|]) []
             pure [sig, val]
+
+-- | Transpose the DataFrame by swapping rows and columns.
+transpose :: DataFrame -> DataFrame
+transpose = fromRows . List.transpose . toRows


### PR DESCRIPTION
Implements a row-major transpose function for the DataFrame library, addressing issue #191.

### Technical Approach
The implementation leverages the library's stable API to ensure structural integrity:
* **toRows**: Converts the internal columnar storage into a standard row-wise list structure ($$[[a]]$$).
* **Data.List.transpose**: Swaps the axes of the list-of-lists.
* **fromRows**: Reconstructs the DataFrame from the transposed result.

### Verification
* **Logic**: Verified via GHCi using a sample matrix rotation ($$[[1,2],[3,4]] \to [[1,3],[2,4]]$$).
* **Cleanliness**: PR is atomic and limited strictly to src/DataFrame/Functions.hs with no unrelated artifacts or dependencies.