### PR TITLE
Improve nix flake

### DIFF
--- a/dataframe-persistent/LICENSE
+++ b/dataframe-persistent/LICENSE
@@ -1,1 +1,20 @@
-../LICENSE
+Copyright (c) 2026 Michael Chavinda
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/flake.nix
+++ b/flake.nix
@@ -17,9 +17,10 @@
           hash = "sha256-Z/o8gxMOBltKiaL0NEjMUyOvUljRvKErWeM6Ul3GM9k=";
         };
 
-        hsPkgs = pkgs.haskellPackages.extend (self: super: rec {
+        hsPkgs = pkgs.haskellPackages.extend (self: super: {
           granite = self.callCabal2nix "granite" granitePkg { };
           dataframe-fastcsv = self.callCabal2nix "dataframe-fastcsv" ./dataframe-fastcsv { };
+          dataframe-persistent = self.callCabal2nix "dataframe-fastcsv" ./dataframe-persistent { };
           dataframe = self.callCabal2nix "dataframe" ./. { };
         });
       in
@@ -28,6 +29,7 @@
           default = hsPkgs.dataframe;
           dataframe = hsPkgs.dataframe;
           dataframe-fastcsv = hsPkgs.dataframe-fastcsv;
+          dataframe-persistent = hsPkgs.dataframe-persistent;
         };
 
         devShells.default = hsPkgs.shellFor {

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
           repo = "granite";
           owner = "mchav";
           rev = "main";
-          hash = "sha256-ypDiV99w2J8q7XcMpFWkv0kEm2dtWZduWIkAsuXDHEo=";
+          hash = "sha256-Z/o8gxMOBltKiaL0NEjMUyOvUljRvKErWeM6Ul3GM9k=";
         };
 
         hsPkgs = pkgs.haskellPackages.extend (self: super: rec {

--- a/flake.nix
+++ b/flake.nix
@@ -19,13 +19,8 @@
 
         hsPkgs = pkgs.haskellPackages.extend (self: super: rec {
           granite = self.callCabal2nix "granite" granitePkg { };
-          dataframe-fastcsv = self.callCabal2nix "dataframe-fastcsv" ./dataframe-fastcsv {
-            inherit parallel;
-          };
-          dataframe = self.callCabal2nix "dataframe" ./. {
-            inherit granite;
-          };
-          parallel = super.parallel_3_3_0_0;
+          dataframe-fastcsv = self.callCabal2nix "dataframe-fastcsv" ./dataframe-fastcsv { };
+          dataframe = self.callCabal2nix "dataframe" ./. { };
         });
       in
       {


### PR DESCRIPTION
* update hash of `granite` so nix build works at all
* include `dataframe-persistent` in package outputs

This PR doesn't include either nix-driven CI or `dataframe-hasktorch` in outputs. Both of those would be good someday, but last time I tried to build `hasktorch` anything I had a rough time.