### PR TITLE
doc: Change declared license to MIT for dataframe-persistent

### DIFF
--- a/dataframe-persistent/dataframe-persistent.cabal
+++ b/dataframe-persistent/dataframe-persistent.cabal
@@ -7,7 +7,7 @@ synopsis: Persistent database integration for the dataframe library
 description: This package provides integration between the dataframe library and the Persistent database library, allowing you to load database entities into DataFrames and save DataFrames back to the database.
 
 bug-reports: https://github.com/mchav/dataframe/issues
-license:            GPL-3.0-or-later
+license:            MIT
 license-file:       ./LICENSE
 author:             Michael Chavinda, Junji Hashimoto
 maintainer:         mschavinda@gmail.com


### PR DESCRIPTION
See comment here:
https://github.com/DataHaskell/dataframe/pull/200#discussion_r3145105287

[On Discord](https://discord.com/channels/1422585768785870868/1462822705123561663/1498353787478216736), we discussed that there's no specific reason for dataframe-persistent to be GPL-licensed, so for commercial compatibility, bumping to a library consistent with the rest of the dataframe artifacts