### PR TITLE
Small project config improvements

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,5 @@
 packages:
     .
     dataframe-fastcsv
+    dataframe-hasktorch
+    dataframe-persistent

--- a/flake.nix
+++ b/flake.nix
@@ -20,7 +20,7 @@
         hsPkgs = pkgs.haskellPackages.extend (self: super: {
           granite = self.callCabal2nix "granite" granitePkg { };
           dataframe-fastcsv = self.callCabal2nix "dataframe-fastcsv" ./dataframe-fastcsv { };
-          dataframe-persistent = self.callCabal2nix "dataframe-fastcsv" ./dataframe-persistent { };
+          dataframe-persistent = self.callCabal2nix "dataframe-persistent" ./dataframe-persistent { };
           dataframe = self.callCabal2nix "dataframe" ./. { };
         });
       in

--- a/flake.nix
+++ b/flake.nix
@@ -21,6 +21,7 @@
           granite = self.callCabal2nix "granite" granitePkg { };
           dataframe-fastcsv = self.callCabal2nix "dataframe-fastcsv" ./dataframe-fastcsv { };
           dataframe-persistent = self.callCabal2nix "dataframe-persistent" ./dataframe-persistent { };
+          dataframe-hasktorch = self.callCabal2nix "dataframe-hasktorch" ./dataframe-hasktorch { };
           dataframe = self.callCabal2nix "dataframe" ./. { };
         });
       in
@@ -29,11 +30,17 @@
           default = hsPkgs.dataframe;
           dataframe = hsPkgs.dataframe;
           dataframe-fastcsv = hsPkgs.dataframe-fastcsv;
+          dataframe-hasktorch = hsPkgs.dataframe-hasktorch;
           dataframe-persistent = hsPkgs.dataframe-persistent;
         };
 
         devShells.default = hsPkgs.shellFor {
-          packages = ps: [ ps.dataframe ps.dataframe-fastcsv ];
+          packages = ps: [
+            ps.dataframe
+            ps.dataframe-fastcsv
+            ps.dataframe-persistent
+            ps.dataframe-hasktorch
+          ];
           nativeBuildInputs = with hsPkgs; [
             ghc
             cabal-install


### PR DESCRIPTION
This PR does a few things that make project setup a little nicer (especially with `nix`, but also without `nix`) --

1. It includes `dataframe-hasktorch` and `dataframe-persistent` in `cabal.project`, which makes it possible to run `cabal repl dataframe-hasktorch` (or `-persistent`) from the repo root and drop into an appropriate dev shell
2. It includes `dataframe-hasktorch` and `dataframe-persistent` in the packages that the `nix` dev shell depends on, so e.g. `ghci`, then `import Torch` / `zeros' ([3, 4] :: [Int])` works (i.e., `ghci` in the nix dev shell has all the dependencies for each of `dataframe` (not new), `dataframe-fastcsv` (not new), `dataframe-persistent` (new!), and `dataframe-hasktorch` (new!))
3. It fixes a boneheaded mistake I made earlier today where I tried to include `dataframe-fastcsv` from the `dataframe-persistent.cabal` file 🤦🏻 I'm not sure why the dev shell didn't throw a tantrum

## Testing instructions

* dev shell improvements
  * `nix develop --command ghci`
  * do any `hasktorch` [examples](https://hasktorch.github.io/tutorial/02-tensors.html)
  * do any persistent examples, e.g. copy [the synopsis](https://www.yesodweb.com/book/persistent#persistent_synopsis) from the persistent book into `persistent-example.hs`, `:l persistent-example.hs` from `ghci`, then run `main`
* repl fixes
  * `cabal repl dataframe-hasktorch`, do `Torch` examples
  * `cabal repl dataframe-persistent-tests` (because of `persistent-sqlite`), then do the same `persistent` example from above, but `:l ../persistent-example.hs` from wherever it is relative to the `dataframe-persistent` directory